### PR TITLE
[maliit] Allow D-Bus activation only through systemd. JB#52572

### DIFF
--- a/maliit-framework/connection/org.maliit.server.service.in
+++ b/maliit-framework/connection/org.maliit.server.service.in
@@ -1,5 +1,5 @@
 [D-BUS Service]
 Name=org.maliit.server
-Exec=/usr/bin/invoker --type=qt5 @BINDIR@/maliit-server @MALIIT_SERVER_ARGUMENTS@
+Exec=/bin/false
 SystemdService=maliit-server.service
 


### PR DESCRIPTION
Starting D-Bus services should happen only via systemd. Using a dummy
Exec line in D-Bus configuration ensures that systemd can't be bypassed.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>