### PR TITLE
[packaging] BuildRequire systemd via pkgconfig. JB#55010

### DIFF
--- a/rpm/maliit-framework-wayland.spec
+++ b/rpm/maliit-framework-wayland.spec
@@ -18,9 +18,9 @@ BuildRequires:  pkgconfig(Qt5Quick)
 BuildRequires:  pkgconfig(Qt5Test)
 BuildRequires:  pkgconfig(libudev)
 BuildRequires:  pkgconfig(mce)
-BuildRequires:  fdupes
+BuildRequires:  pkgconfig(systemd)
 BuildRequires:  pkgconfig(qt5-boostable)
-BuildRequires:  systemd
+BuildRequires:  fdupes
 Requires:   mapplauncherd-qt5
 Provides:   maliit-framework
 Conflicts:   maliit-framework-x11


### PR DESCRIPTION
This allows to pick systemd-mini inside the builder instead of full
systemd.

Signed-off-by: Björn Bidar <bjorn.bidar@jolla.com>