### PR TITLE
[maliit-framework] Ensure all unit test files are installed. JB#62387

### DIFF
--- a/rpm/maliit-framework-wayland.spec
+++ b/rpm/maliit-framework-wayland.spec
@@ -89,7 +89,8 @@ maliit keyboard via glib apis
       -Denable-glib=ON \
       -Denable-xcb=OFF \
       -Denable-wayland=OFF \
-      -Denable-dbus-activation=ON
+      -Denable-dbus-activation=ON \
+      -Dinstall-tests=ON
 
 %cmake_build
 


### PR DESCRIPTION
2.3.0 update broke the qml test by not installing test qml file anymore. The update introduced "install-tests" option, but looks like it's now installing part of the tests anyway, making them almost work.

Simple fix is just to ensure the option is turned on.